### PR TITLE
Extend basic experiment with Gutenberg Block #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # WordPress
 
+**Contents** [Overview] | [Getting started] | [Usage] | [Contributing] | [References]  
+
 This repository contains [WordPress] [sample environments][Samples] and [experimental extensions][Extensions].
 
 ## Overview
 
 For working in a comfortable, platform-agnostic way with proper isolation between different workloads, this repository supports working with [Vagrant], managing separate virtual machines for each environment with [VirtualBox], and connecting to them via [Visual Studio Code]. For ensuring that all the settings work as expected, they are automatically verified with [Azure DevOps].
+
+[Overview]: #overview
 
 ## Getting started
 
@@ -71,7 +75,7 @@ Once you're done exploring the sample, you can clean up your environment. Using 
 - Type `vagrant destroy samples.gutenberg-block` to remove the virtual machine.
   - This will permanently delete the state, including any changes to the cloned repositories. Typing `vagrant up samples.gutenberg-block` again will get you a brand new environment.
 
-In case you encounter any issues, take a look at and try to follow the process of the [latest automated build][Gutenberg Block Build Log] in Azure DevOps. If you need any more help, have further questions or feedback, please feel free to [open an issue][Contributing].
+In case you encounter any issues, take a look at and try to follow the process of the [latest automated build][Samples Gutenberg Block Build Log] in Azure DevOps. If you need any more help, have further questions or feedback, please feel free to [open an issue][Contributing].
 
 ## Usage
 
@@ -119,7 +123,7 @@ This is a sample environment for Gutenberg Editor development based on the [gett
 
 #### Gutenberg Block
 
-[![Gutenberg Block Build Status]][Gutenberg Block Build Log]
+[![Samples Gutenberg Block Build Status]][Samples Gutenberg Block Build Log]
 
 This is a sample environment for Gutenberg Block development based on the [getting started description][Gutenberg Block Getting Started]. Please see the [handbook][Gutenberg Block Handbook] for more information.
 
@@ -129,14 +133,41 @@ This is a sample environment for Gutenberg Block development based on the [getti
 
 [Gutenberg Block]: #gutenberg-block
 
-[Gutenberg Block Build Status]: https://dev.azure.com/gusztavvargadr/wordpress/_apis/build/status/samples.gutenberg-block?branchName=master
-[Gutenberg Block Build Log]: https://dev.azure.com/gusztavvargadr/wordpress/_build/latest?definitionId=300&branchName=master
+[Samples Gutenberg Block Build Status]: https://dev.azure.com/gusztavvargadr/wordpress/_apis/build/status/samples.gutenberg-block?branchName=master
+[Samples Gutenberg Block Build Log]: https://dev.azure.com/gusztavvargadr/wordpress/_build/latest?definitionId=300&branchName=master
 [Gutenberg Block Getting Started]: https://github.com/WordPress/gutenberg-examples#development
 [Gutenberg Block Handbook]: https://developer.wordpress.org/block-editor/tutorials/block-tutorial/
 
 ### Extensions
 
 [Extensions]: #extensions
+
+#### Gutenberg Block
+
+[![Extensions Gutenberg Block Build Status]][Extensions Gutenberg Block Build Log]
+
+This environment contains custom extensions for Gutenberg Block experiments.
+
+- Vagrant Environment `vagrant up src.gutenberg-block`
+- Visual Studio Code Remote SSH Target `src.gutenberg-block`
+- Visual Studio Code Remote SSH Forwarded Port http://localhost:40080
+
+After launching the environment, walk through the initial WordPress installation and activate the following plugins to to use the blocks.
+
+[Extensions Gutenberg Block Build Status]: https://dev.azure.com/gusztavvargadr/wordpress/_apis/build/status/src.gutenberg-block?branchName=master
+[Extensions Gutenberg Block Build Log]: https://dev.azure.com/gusztavvargadr/wordpress/_build/latest?definitionId=301&branchName=master
+
+##### Hello
+
+The plugin `Gutenberg Block Hello` implements the following blocks:
+
+- [Gutenberg Block Hello Quote Style], a style that can be applied to `Quote` blocks.
+- [Gutenberg Block Hello Static ESNext], a block showing static text.
+- [Gutenberg Block Hello Editable ESNext], a block showing editable text.
+
+[Gutenberg Block Hello Quote Style]: ./src/gutenberg-block/wordpress/hello/quote-style/
+[Gutenberg Block Hello Static ESNext]: ./src/gutenberg-block/wordpress/hello/static-esnext/
+[Gutenberg Block Hello Editable ESNext]: ./src/gutenberg-block/wordpress/hello/editable-esnext/
 
 ## Contributing
 

--- a/src/gutenberg-block/vagrant/build.sh
+++ b/src/gutenberg-block/vagrant/build.sh
@@ -2,6 +2,10 @@
 
 cd ~/source/src/gutenberg-block/wordpress/
 
-pushd ./hello/js/
+pushd ./hello/static-esnext/
+npm run build
+popd
+
+pushd ./hello/editable-esnext/
 npm run build
 popd

--- a/src/gutenberg-block/vagrant/restore.sh
+++ b/src/gutenberg-block/vagrant/restore.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-cd ~/source/src/gutenberg-block/wordpress/
-
-pushd ./hello/js/
 sudo npm install --global @wordpress/scripts@9.0
-popd

--- a/src/gutenberg-block/wordpress/hello/editable-esnext/editor.css
+++ b/src/gutenberg-block/wordpress/hello/editable-esnext/editor.css
@@ -1,0 +1,6 @@
+.wp-block-gutenberg-block-hello-editable-esnext {
+  color: darkred;
+  background: #fcc;
+  border: 2px solid #c99;
+  padding: 20px;
+}

--- a/src/gutenberg-block/wordpress/hello/editable-esnext/index.php
+++ b/src/gutenberg-block/wordpress/hello/editable-esnext/index.php
@@ -1,0 +1,34 @@
+<?php
+
+function gutenberg_block_hello_editable_esnext_register_block() {
+  $asset_file = include( plugin_dir_path( __FILE__ ) . 'build/index.asset.php');
+
+  wp_register_script(
+      'gutenberg-block-editable-esnext-editor',
+      plugins_url( 'build/index.js', __FILE__ ),
+      $asset_file['dependencies'],
+      $asset_file['version']
+  );
+
+  wp_register_style(
+      'gutenberg-block-editable-esnext-editor',
+      plugins_url( 'editor.css', __FILE__ ),
+      array( 'wp-edit-blocks' ),
+      filemtime( plugin_dir_path( __FILE__ ) . 'editor.css' )
+  );
+
+  wp_register_style(
+      'gutenberg-block-editable-esnext',
+      plugins_url( 'style.css', __FILE__ ),
+      array( ),
+      filemtime( plugin_dir_path( __FILE__ ) . 'style.css' )
+  );
+
+  register_block_type( 'gutenberg-block-hello/editable-esnext', array(
+      'style' => 'gutenberg-block-editable-esnext',
+      'editor_style' => 'gutenberg-block-editable-esnext-editor',
+      'editor_script' => 'gutenberg-block-editable-esnext-editor',
+  ) );
+}
+
+add_action( 'init', 'gutenberg_block_hello_editable_esnext_register_block' );

--- a/src/gutenberg-block/wordpress/hello/editable-esnext/package.json
+++ b/src/gutenberg-block/wordpress/hello/editable-esnext/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gutenberg-block-hello-js",
+  "name": "gutenberg-block-hello-editable-esnext",
   "version": "1.0.0",
-  "description": "Gutenberg Block Hello JS",
+  "description": "Gutenberg Block Hello Editable ESNext",
   "main": "build/index.js",
   "scripts": {
     "build": "wp-scripts build",

--- a/src/gutenberg-block/wordpress/hello/editable-esnext/src/index.js
+++ b/src/gutenberg-block/wordpress/hello/editable-esnext/src/index.js
@@ -1,0 +1,37 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { RichText } from '@wordpress/block-editor';
+
+registerBlockType('gutenberg-block-hello/editable-esnext', {
+  title: 'Gutenberg Block Hello Editable ESNext',
+  icon: 'universal-access-alt',
+  category: 'common',
+  attributes: {
+    content: {
+      type: 'array',
+      source: 'children',
+      selector: 'p',
+    },
+  },
+  example: {
+    attributes: {
+      content: 'Gutenberg Block Hello Editable ESNext'
+    },
+  },
+  edit: (props) => {
+    const { attributes: { content }, setAttributes, className } = props;
+    const onChangeContent = (newContent) => {
+      setAttributes({ content: newContent });
+    };
+    return (
+      <RichText
+        tagName="p"
+        className={className}
+        onChange={onChangeContent}
+        value={content}
+      />
+    );
+  },
+  save: (props) => {
+    return <RichText.Content tagName="p" value={props.attributes.content} />;
+  },
+});

--- a/src/gutenberg-block/wordpress/hello/editable-esnext/style.css
+++ b/src/gutenberg-block/wordpress/hello/editable-esnext/style.css
@@ -1,0 +1,6 @@
+.wp-block-gutenberg-block-hello-editable-esnext {
+  color: green;
+  background: #cfc;
+  border: 2px solid #9c9;
+  padding: 20px;
+}

--- a/src/gutenberg-block/wordpress/hello/index.php
+++ b/src/gutenberg-block/wordpress/hello/index.php
@@ -3,29 +3,6 @@
 Plugin Name: Gutenberg Block Hello
 */
 
-function gutenberg_block_hello_enqueue_script() {
-  wp_enqueue_script(
-      'gutenberg-block-hello-quote',
-      plugins_url( 'quote/index.js', __FILE__ ),
-      array( 'wp-blocks' )
-  );
-
-  $js_asset_file = include( plugin_dir_path( __FILE__ ) . 'js/build/index.asset.php');
-
-  wp_enqueue_script(
-      'gutenberg-block-hello-js',
-      plugins_url( 'js/build/index.js', __FILE__ ),
-      $js_asset_file['dependencies'],
-      $js_asset_file['version']
-  );
-}
-
-function gutenberg_block_hello_enqueue_style() {
-  wp_enqueue_style(
-    'gutenberg-block-hello-quote',
-    plugins_url( 'quote/style.css', __FILE__ )
-  );
-}
-
-add_action( 'enqueue_block_editor_assets', 'gutenberg_block_hello_enqueue_script' );
-add_action( 'enqueue_block_assets', 'gutenberg_block_hello_enqueue_style' );
+include 'quote-style/index.php';
+include 'static-esnext/index.php';
+include 'editable-esnext/index.php';

--- a/src/gutenberg-block/wordpress/hello/js/src/index.js
+++ b/src/gutenberg-block/wordpress/hello/js/src/index.js
@@ -1,9 +1,0 @@
-import { registerBlockType } from '@wordpress/blocks';
-
-registerBlockType('gutenberg-block-hello/js', {
-  title: 'Hello JS',
-  icon: 'smiley',
-  category: 'common',
-  edit: () => <div>Hello from JS (edit)!</div>,
-  save: () => <div>Hello from JS (save)!</div>,
-});

--- a/src/gutenberg-block/wordpress/hello/quote-style/index.js
+++ b/src/gutenberg-block/wordpress/hello/quote-style/index.js
@@ -1,0 +1,6 @@
+(function () {
+  wp.blocks.registerBlockStyle('core/quote', {
+    name: 'gutenberg-block-hello-quote-style',
+    label: 'Gutenberg Block Hello Quote Style',
+  });
+})()

--- a/src/gutenberg-block/wordpress/hello/quote-style/index.php
+++ b/src/gutenberg-block/wordpress/hello/quote-style/index.php
@@ -1,0 +1,19 @@
+<?php
+
+function gutenberg_block_hello_quote_style_enqueue_script() {
+  wp_enqueue_script(
+      'gutenberg-block-hello-quote-style',
+      plugins_url( 'index.js', __FILE__ ),
+      array( 'wp-blocks' )
+  );
+}
+
+function gutenberg_block_hello_quote_style_enqueue_style() {
+  wp_enqueue_style(
+    'gutenberg-block-hello-quote-style',
+    plugins_url( 'style.css', __FILE__ )
+  );
+}
+
+add_action( 'enqueue_block_editor_assets', 'gutenberg_block_hello_quote_style_enqueue_script' );
+add_action( 'enqueue_block_assets', 'gutenberg_block_hello_quote_style_enqueue_style' );

--- a/src/gutenberg-block/wordpress/hello/quote-style/style.css
+++ b/src/gutenberg-block/wordpress/hello/quote-style/style.css
@@ -1,0 +1,3 @@
+.is-style-gutenberg-block-hello-quote-style {
+  color: gold;
+}

--- a/src/gutenberg-block/wordpress/hello/quote/index.js
+++ b/src/gutenberg-block/wordpress/hello/quote/index.js
@@ -1,6 +1,0 @@
-(function () {
-  wp.blocks.registerBlockStyle('core/quote', {
-    name: 'hello-quote',
-    label: 'Hello Quote',
-  });
-})()

--- a/src/gutenberg-block/wordpress/hello/quote/style.css
+++ b/src/gutenberg-block/wordpress/hello/quote/style.css
@@ -1,3 +1,0 @@
-.is-style-hello-quote {
-  color: gold;
-}

--- a/src/gutenberg-block/wordpress/hello/static-esnext/index.php
+++ b/src/gutenberg-block/wordpress/hello/static-esnext/index.php
@@ -1,0 +1,14 @@
+<?php
+
+function gutenberg_block_hello_static_esnext_enqueue_script() {
+  $asset_file = include( plugin_dir_path( __FILE__ ) . 'build/index.asset.php' );
+
+  wp_enqueue_script(
+      'gutenberg-block-hello-static-esnext',
+      plugins_url( 'build/index.js', __FILE__ ),
+      $asset_file['dependencies'],
+      $asset_file['version']
+  );
+}
+
+add_action( 'enqueue_block_editor_assets', 'gutenberg_block_hello_static_esnext_enqueue_script' );

--- a/src/gutenberg-block/wordpress/hello/static-esnext/package.json
+++ b/src/gutenberg-block/wordpress/hello/static-esnext/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gutenberg-block-hello-static-esnext",
+  "version": "1.0.0",
+  "description": "Gutenberg Block Hello Static ESNext",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "wp-scripts build",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "gusztavvargadr",
+  "license": "MIT",
+  "devDependencies": {
+    "@wordpress/scripts": "9.0"
+  }
+}

--- a/src/gutenberg-block/wordpress/hello/static-esnext/src/index.js
+++ b/src/gutenberg-block/wordpress/hello/static-esnext/src/index.js
@@ -1,0 +1,9 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+registerBlockType('gutenberg-block-hello/static-esnext', {
+  title: 'Gutenberg Block Hello Static ESNext',
+  icon: 'smiley',
+  category: 'common',
+  edit: () => <div>Hello from Static ESNext (edit)!</div>,
+  save: () => <div>Hello from Static ESNext (save)!</div>,
+});


### PR DESCRIPTION
### Summary

- Refactor current experiment.
- Add editable block with ESNext.
- Add documentation.

### Details

#### Editable block

Editor | Preview
--- | ---
<img width="250" alt="gutenberg-block-hello-editable-esnext-edit" src="https://user-images.githubusercontent.com/1721722/87077167-03b41980-c223-11ea-8e8a-8b61be438496.png"> | <img width="250" alt="gutenberg-block-hello-editable-esnext-save" src="https://user-images.githubusercontent.com/1721722/87077171-044cb000-c223-11ea-9523-ccfa24cde23e.png">

### References

- Resolves #10.
